### PR TITLE
Feat/generate session endpoint

### DIFF
--- a/AuthMicroservice Backend/.gitattributes
+++ b/AuthMicroservice Backend/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/AuthMicroservice Backend/.gitignore
+++ b/AuthMicroservice Backend/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/AuthMicroservice Backend/.mvn/wrapper/maven-wrapper.properties
+++ b/AuthMicroservice Backend/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/AuthMicroservice Backend/docker-compose.yml
+++ b/AuthMicroservice Backend/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.9'
+
+services: 
+  db:
+    image: postgres:12-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5466:5432"

--- a/AuthMicroservice Backend/docker-compose.yml
+++ b/AuthMicroservice Backend/docker-compose.yml
@@ -10,3 +10,8 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5466:5432"
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"

--- a/AuthMicroservice Backend/mvnw
+++ b/AuthMicroservice Backend/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/AuthMicroservice Backend/mvnw.cmd
+++ b/AuthMicroservice Backend/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/AuthMicroservice Backend/pom.xml
+++ b/AuthMicroservice Backend/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.0</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>upb.edu</groupId>
+	<artifactId>AuthMicroservice</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Auth Microservice Backend</name>
+	<description>Auth Microservice</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/AuthMicroserviceBackendApplication.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/AuthMicroserviceBackendApplication.java
@@ -1,0 +1,13 @@
+package upb.edu.AuthMicroservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AuthMicroserviceBackendApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AuthMicroserviceBackendApplication.class, args);
+	}
+
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/SessionController.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/SessionController.java
@@ -1,30 +1,43 @@
 package upb.edu.AuthMicroservice.controllers;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
 import upb.edu.AuthMicroservice.dtos.GenerateSessionRequest;
 import upb.edu.AuthMicroservice.services.SessionService;
 
 import java.util.Map;
 
-@RestController
-@RequestMapping("/")
+@Component
 public class SessionController {
 
-    @Autowired
-    private SessionService sessionService;
+    private final SessionService sessionService;
 
-    @PostMapping("/generate-session")
-    public ResponseEntity<Map<String, Object>> generateSession(@RequestBody GenerateSessionRequest request) {
-        String sessionId = sessionService.generateSession(request.getUser_id());
+    public SessionController(SessionService sessionService) {
+        this.sessionService = sessionService;
+    }
 
-        return ResponseEntity.status(201).body(
-                Map.of(
-                        "code", 201,
-                        "msg", "Sesión creada exitosamente",
-                        "session_id", sessionId
-                )
+    public ServerResponse generateSession(ServerRequest request) {
+        GenerateSessionRequest dto;
+        try {
+            dto = request.body(GenerateSessionRequest.class);
+        } catch (Exception e) {
+            return ServerResponse
+                    .badRequest()
+                    .body(Map.of(
+                            "code", 400,
+                            "msg",  "JSON inválido: " + e.getMessage()
+                    ));
+        }
+        String sessionId = sessionService.generateSession(dto.getUser_id());
+
+        Map<String, Object> body = Map.of(
+                "code",       201,
+                "msg",        "Sesión creada exitosamente",
+                "session_id", sessionId
         );
+        return ServerResponse
+                .status(201)
+                .body(body);
     }
 }

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/SessionController.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/SessionController.java
@@ -1,37 +1,30 @@
 package upb.edu.AuthMicroservice.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import upb.edu.AuthMicroservice.models.Session;
-import upb.edu.AuthMicroservice.models.GenerateSessionRequest;
-import upb.edu.AuthMicroservice.repositories.SessionRepository;
+import upb.edu.AuthMicroservice.dtos.GenerateSessionRequest;
+import upb.edu.AuthMicroservice.services.SessionService;
 
-import java.time.LocalDateTime;
-import java.util.*;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/")
 public class SessionController {
 
     @Autowired
-    private SessionRepository sessionRepository;
+    private SessionService sessionService;
 
     @PostMapping("/generate-session")
-    public Map<String, Object> generateSession(@RequestBody GenerateSessionRequest request) {
-        Session session = new Session();
-        session.setId(UUID.randomUUID());
-        session.setUserId(request.getUser_id());
-        session.setCreatedAt(LocalDateTime.now());
-        session.setExpiresAt(LocalDateTime.now().plusHours(1));
-        session.setIsValid(true);
+    public ResponseEntity<Map<String, Object>> generateSession(@RequestBody GenerateSessionRequest request) {
+        String sessionId = sessionService.generateSession(request.getUser_id());
 
-        sessionRepository.save(session);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("code", 201);
-        response.put("msg", "Sesión creada exitosamente");
-        response.put("session_id", session.getId().toString());
-
-        return response;
+        return ResponseEntity.status(201).body(
+                Map.of(
+                        "code", 201,
+                        "msg", "Sesión creada exitosamente",
+                        "session_id", sessionId
+                )
+        );
     }
 }

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/SessionController.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/SessionController.java
@@ -1,0 +1,37 @@
+package upb.edu.AuthMicroservice.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import upb.edu.AuthMicroservice.models.Session;
+import upb.edu.AuthMicroservice.models.GenerateSessionRequest;
+import upb.edu.AuthMicroservice.repositories.SessionRepository;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@RestController
+@RequestMapping("/")
+public class SessionController {
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @PostMapping("/generate-session")
+    public Map<String, Object> generateSession(@RequestBody GenerateSessionRequest request) {
+        Session session = new Session();
+        session.setId(UUID.randomUUID());
+        session.setUserId(request.getUser_id());
+        session.setCreatedAt(LocalDateTime.now());
+        session.setExpiresAt(LocalDateTime.now().plusHours(1));
+        session.setIsValid(true);
+
+        sessionRepository.save(session);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("code", 201);
+        response.put("msg", "Sesión creada exitosamente");
+        response.put("session_id", session.getId().toString());
+
+        return response;
+    }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/UserController.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/UserController.java
@@ -1,0 +1,18 @@
+package upb.edu.AuthMicroservice.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RestController;
+
+import upb.edu.AuthMicroservice.models.User;
+import upb.edu.AuthMicroservice.services.UserService;
+
+@RestController
+public class UserController {
+
+    @Autowired
+    private UserService userService;
+
+    public User registerUser(User user) {
+        return userService.createUser(user);
+    }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/dtos/GenerateSessionRequest.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/dtos/GenerateSessionRequest.java
@@ -1,4 +1,4 @@
-package upb.edu.AuthMicroservice.models;
+package upb.edu.AuthMicroservice.dtos;
 
 public class GenerateSessionRequest {
     private int user_id;

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/interactors/GenerateSessionInteractor.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/interactors/GenerateSessionInteractor.java
@@ -1,0 +1,28 @@
+package upb.edu.AuthMicroservice.interactors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import upb.edu.AuthMicroservice.models.Session;
+import upb.edu.AuthMicroservice.repositories.SessionRepository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+public class GenerateSessionInteractor {
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    public UUID execute(int userId) {
+        Session session = new Session();
+        session.setId(UUID.randomUUID());
+        session.setUserId(userId);
+        session.setCreatedAt(LocalDateTime.now());
+        session.setExpiresAt(LocalDateTime.now().plusHours(1));
+        session.setIsValid(true);
+
+        sessionRepository.save(session);
+        return session.getId();
+    }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/interactors/SessionInteractor.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/interactors/SessionInteractor.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Component
-public class GenerateSessionInteractor {
+public class SessionInteractor {
 
     @Autowired
     private SessionRepository sessionRepository;

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/interactors/UserInteractor.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/interactors/UserInteractor.java
@@ -1,0 +1,20 @@
+package upb.edu.AuthMicroservice.interactors;
+
+import org.springframework.stereotype.Service;
+
+import upb.edu.AuthMicroservice.models.User;
+import upb.edu.AuthMicroservice.repositories.UserRepository;
+
+@Service
+public class UserInteractor {
+    private final UserRepository userRepository;
+    
+    public UserInteractor(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User createUser(User user) {
+        return userRepository.save(user);
+    }
+
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/GenerateSessionRequest.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/GenerateSessionRequest.java
@@ -1,0 +1,13 @@
+package upb.edu.AuthMicroservice.models;
+
+public class GenerateSessionRequest {
+    private int user_id;
+
+    public int getUser_id() {
+        return user_id;
+    }
+
+    public void setUser_id(int user_id) {
+        this.user_id = user_id;
+    }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/Response.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/Response.java
@@ -1,0 +1,16 @@
+package upb.edu.AuthMicroservice.models;
+
+public class Response {
+    private String code;
+    private String msg;
+
+    public Response(String code, String msg) {
+        this.code = code;
+        this.msg = msg;
+    }
+
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getMsg() { return msg; }
+    public void setMsg(String msg) { this.msg = msg; }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/Session.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/Session.java
@@ -14,8 +14,13 @@ public class Session {
     @Column(name = "user_id")
     private int userId;
 
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
+
+    @Column(name = "expires_at")
     private LocalDateTime expiresAt;
+
+    @Column(name = "is_valid")
     private boolean isValid;
 
     public Session() {}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/Session.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/Session.java
@@ -1,0 +1,64 @@
+package upb.edu.AuthMicroservice.models;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "session")
+public class Session {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id")
+    private int userId;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime expiresAt;
+    private boolean isValid;
+
+    public Session() {}
+
+    // Getters y Setters
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(LocalDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isValid() {
+        return isValid;
+    }
+
+    public void setIsValid(boolean isValid) {
+        this.isValid = isValid;
+    }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/User.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/User.java
@@ -1,0 +1,54 @@
+package upb.edu.AuthMicroservice.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Date;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+@Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;    
+    private String email;
+
+    private String password;
+
+    @JsonProperty("first_name")
+    private String firstName;
+
+    @JsonProperty("middle_name")
+    private String middleName;
+
+    @JsonProperty("last_name")
+    private String lastName;
+    private String code;
+
+    @JsonProperty("enrollment_date")
+    private Date enrollmentDate;
+
+    public User() {}
+
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+    public String getMiddleName() { return middleName; }
+    public void setMiddleName(String middleName) { this.middleName = middleName; }
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public Date getEnrollmentDate() { return enrollmentDate; }
+    public void setEnrollmentDate(Date enrollmentDate) { this.enrollmentDate = enrollmentDate; }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/repositories/SessionRepository.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/repositories/SessionRepository.java
@@ -1,0 +1,9 @@
+package upb.edu.AuthMicroservice.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import upb.edu.AuthMicroservice.models.Session;
+
+import java.util.UUID;
+
+public interface SessionRepository extends JpaRepository<Session, UUID> {
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/repositories/UserRepository.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/repositories/UserRepository.java
@@ -1,0 +1,8 @@
+package upb.edu.AuthMicroservice.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import upb.edu.AuthMicroservice.models.User;
+
+public interface UserRepository extends JpaRepository<User, String> {
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/routes/Routes.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/routes/Routes.java
@@ -1,0 +1,31 @@
+package upb.edu.AuthMicroservice.routes;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import upb.edu.AuthMicroservice.controllers.UserController;
+import upb.edu.AuthMicroservice.models.Response;
+import upb.edu.AuthMicroservice.models.User;
+
+import static org.springframework.web.servlet.function.RouterFunctions.route;
+
+@Configuration
+public class Routes {
+
+    @Autowired
+    private UserController userController;
+
+    @Bean
+    public RouterFunction<ServerResponse> userRoutes() {
+        return route()
+                .POST("/register-user", request -> {
+                    User user = request.body(User.class);
+                    userController.registerUser(user);
+                    return ServerResponse.ok().body(new Response("201", "OK"));
+                })
+                .build();
+    }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/routes/Routes.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/routes/Routes.java
@@ -1,22 +1,29 @@
 package upb.edu.AuthMicroservice.routes;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.ServerResponse;
 
 import upb.edu.AuthMicroservice.controllers.UserController;
+import upb.edu.AuthMicroservice.controllers.SessionController;
 import upb.edu.AuthMicroservice.models.Response;
 import upb.edu.AuthMicroservice.models.User;
 
 import static org.springframework.web.servlet.function.RouterFunctions.route;
+import static org.springframework.web.servlet.function.RequestPredicates.POST;
 
 @Configuration
 public class Routes {
 
-    @Autowired
-    private UserController userController;
+    private final UserController    userController;
+    private final SessionController sessionController;
+
+    public Routes(UserController userController,
+                  SessionController sessionController) {
+        this.userController    = userController;
+        this.sessionController = sessionController;
+    }
 
     @Bean
     public RouterFunction<ServerResponse> userRoutes() {
@@ -24,8 +31,18 @@ public class Routes {
                 .POST("/register-user", request -> {
                     User user = request.body(User.class);
                     userController.registerUser(user);
-                    return ServerResponse.ok().body(new Response("201", "OK"));
+                    return ServerResponse
+                            .ok()
+                            .body(new Response("201", "OK"));
                 })
+                .build();
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> sessionRoutes() {
+        return route()
+                // Aquí movemos la ruta /generate-session
+                .POST("/generate-session", sessionController::generateSession)
                 .build();
     }
 }

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/SessionService.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/SessionService.java
@@ -2,13 +2,13 @@ package upb.edu.AuthMicroservice.services;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import upb.edu.AuthMicroservice.interactors.GenerateSessionInteractor;
+import upb.edu.AuthMicroservice.interactors.SessionInteractor;
 
 @Service
 public class SessionService {
 
     @Autowired
-    private GenerateSessionInteractor interactor;
+    private SessionInteractor interactor;
 
     public String generateSession(int userId) {
         return interactor.execute(userId).toString();

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/SessionService.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/SessionService.java
@@ -1,0 +1,16 @@
+package upb.edu.AuthMicroservice.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import upb.edu.AuthMicroservice.interactors.GenerateSessionInteractor;
+
+@Service
+public class SessionService {
+
+    @Autowired
+    private GenerateSessionInteractor interactor;
+
+    public String generateSession(int userId) {
+        return interactor.execute(userId).toString();
+    }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/UserService.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/UserService.java
@@ -1,0 +1,21 @@
+package upb.edu.AuthMicroservice.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import upb.edu.AuthMicroservice.interactors.UserInteractor;
+import upb.edu.AuthMicroservice.models.User;
+
+@Service
+public class UserService {
+    private final UserInteractor userInteractor;
+
+    @Autowired
+    public UserService(UserInteractor userInteractor) {
+        this.userInteractor = userInteractor;
+    }
+
+    public User createUser(User user) {
+        return userInteractor.createUser(user);
+    }
+}

--- a/AuthMicroservice Backend/src/main/resources/application.properties
+++ b/AuthMicroservice Backend/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+spring.application.name=Auth Microservice Backend
+
+spring.datasource.url=jdbc:postgresql://localhost:5466/postgres
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=update
+
+debug=true
+logging.level.org.springframework.boot.autoconfigure=ERROR

--- a/AuthMicroservice Backend/src/test/java/upb/edu/AuthMicroservice/AuthMicroserviceBackendApplicationTests.java
+++ b/AuthMicroservice Backend/src/test/java/upb/edu/AuthMicroservice/AuthMicroserviceBackendApplicationTests.java
@@ -1,0 +1,13 @@
+package upb.edu.AuthMicroservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AuthMicroserviceBackendApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
BUG
Antes no existía un endpoint para generar sesiones de usuarios.
El sistema no contaba con una forma de iniciar sesión o crear una sesión válida para un usuario. No se podía registrar ninguna sesión en la base de datos, ni había lógica que genere un session_id con UUID.

FIX
Se implementó el endpoint:
POST /generate-session
¿Qué hace?
Recibe un user_id por JSON.
Crea una sesión válida (is_valid = true) en la base de datos.
Genera un UUID para la sesión.
Devuelve un mensaje de éxito, código 201 y el session_id

Archivos nuevos creados:
SessionController.java
Session.java
GenerateSessionRequest.java
SessionRepository.java
![image](https://github.com/user-attachments/assets/8af633c6-c318-446a-879c-38dbdfa2e4e7)
