### PR TITLE
feat: separate users table into users and user_profiles

### DIFF
--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/User.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/User.java
@@ -1,39 +1,29 @@
 package upb.edu.AuthMicroservice.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import java.util.Date;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "users")
 public class User {
 
-@Id
+    @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;    
+    private int id;
+
     private String email;
 
     private String password;
 
-    @JsonProperty("first_name")
-    private String firstName;
+    @JsonProperty("is_validated")
+    @Column(name = "is_validated")
+    private boolean isValidated = false;
 
-    @JsonProperty("middle_name")
-    private String middleName;
-
-    @JsonProperty("last_names")
-    private String lastName;
-    private String code;
-
-    @JsonProperty("enrollment_date")
-    private Date enrollmentDate;
-
-    public User() {}
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "user_profile_id", referencedColumnName = "id")
+    @JsonUnwrapped
+    private UserProfile userProfile;
 
     public int getId() { return id; }
     public void setId(int id) { this.id = id; }
@@ -41,14 +31,8 @@ public class User {
     public void setEmail(String email) { this.email = email; }
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
-    public String getFirstName() { return firstName; }
-    public void setFirstName(String firstName) { this.firstName = firstName; }
-    public String getMiddleName() { return middleName; }
-    public void setMiddleName(String middleName) { this.middleName = middleName; }
-    public String getLastName() { return lastName; }
-    public void setLastName(String lastName) { this.lastName = lastName; }
-    public String getCode() { return code; }
-    public void setCode(String code) { this.code = code; }
-    public Date getEnrollmentDate() { return enrollmentDate; }
-    public void setEnrollmentDate(Date enrollmentDate) { this.enrollmentDate = enrollmentDate; }
+    public boolean isValidated() { return isValidated; }
+    public void setValidated(boolean validated) { isValidated = validated; }
+    public UserProfile getUserProfile() { return userProfile; }
+    public void setUserProfile(UserProfile userProfile) { this.userProfile = userProfile; }
 }

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/UserProfile.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/UserProfile.java
@@ -1,0 +1,51 @@
+package upb.edu.AuthMicroservice.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import java.util.Date;
+
+@Entity
+@Table(name = "user_profiles")
+public class UserProfile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @JsonProperty("first_name")
+    @Column(name = "first_name")
+    private String firstName;
+
+    @JsonProperty("middle_name")
+    @Column(name = "middle_name")
+    private String middleName;
+
+    @JsonProperty("last_names")
+    @Column(name = "last_names")
+    private String lastName;
+
+    private String code;
+
+    @JsonProperty("enrollment_date")
+    @Column(name = "enrollment_date")
+    private Date enrollmentDate;
+
+    @OneToOne(mappedBy = "userProfile")
+    @JsonIgnore
+    private User user;
+
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+    public String getMiddleName() { return middleName; }
+    public void setMiddleName(String middleName) { this.middleName = middleName; }
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public Date getEnrollmentDate() { return enrollmentDate; }
+    public void setEnrollmentDate(Date enrollmentDate) { this.enrollmentDate = enrollmentDate; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/repositories/UserProfileRepository.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/repositories/UserProfileRepository.java
@@ -1,0 +1,9 @@
+package upb.edu.AuthMicroservice.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import upb.edu.AuthMicroservice.models.UserProfile;
+
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserProfile, Integer> {
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/UserService.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/UserService.java
@@ -3,10 +3,7 @@ package upb.edu.AuthMicroservice.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-
 import upb.edu.AuthMicroservice.interactors.SessionInteractor;
-
-
 import upb.edu.AuthMicroservice.interactors.UserInteractor;
 import upb.edu.AuthMicroservice.models.User;
 
@@ -14,8 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-
-
 
 @Service
 public class UserService {
@@ -29,6 +24,9 @@ public class UserService {
     }
 
     public User createUser(User user) {
+        if (user.getUserProfile() != null) {
+            user.getUserProfile().setUser(user);
+        }
         return userInteractor.createUser(user);
     }
 


### PR DESCRIPTION
<img width="617" height="199" alt="image" src="https://github.com/user-attachments/assets/882ef84e-cff8-4d3b-a460-ad945df75014" />
<img width="935" height="490" alt="image" src="https://github.com/user-attachments/assets/0757b3fa-df9d-4acd-b960-431320f8a088" />
mplementa la separación de la tabla Users en dos tablas:

Users: contiene solo la información de autenticación (id, email, password, is_validated, user_profile_id).
UserProfiles: contiene la información del usuario (first_name, middle_name, last_names, code, enrollment_date).