### PR TITLE
feat(auth): Add logout endpoint

### DIFF
--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/SessionController.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/SessionController.java
@@ -7,6 +7,7 @@ import org.springframework.web.servlet.function.ServerRequest;
 import org.springframework.web.servlet.function.ServerResponse;
 import upb.edu.AuthMicroservice.models.Response;
 import upb.edu.AuthMicroservice.models.Session;
+import upb.edu.AuthMicroservice.models.LogoutRequest;
 import upb.edu.AuthMicroservice.services.SessionService;
 import upb.edu.AuthMicroservice.dtos.RefreshTokenRequest;
 import upb.edu.AuthMicroservice.exceptions.InvalidRefreshTokenException;
@@ -151,6 +152,38 @@ public class SessionController {
         } catch (Exception ex) {
             logger.error("Error en /refresh-token", ex);
             return ServerResponse.status(500).body(new Response("500", "Error interno al refrescar el token"));
+        }
+    }
+
+    public ServerResponse logout(ServerRequest request) {
+        LogoutRequest logoutRequest;
+        try {
+            logoutRequest = request.body(LogoutRequest.class);
+        } catch (Exception e) {
+            return ServerResponse.badRequest().body(new Response("400", "JSON inválido: " + e.getMessage()));
+        }
+
+        try {
+            boolean success = sessionService.logout(
+                logoutRequest.getEmail(),
+                logoutRequest.getPassword(),
+                logoutRequest.getSession()
+            );
+
+            if (success) {
+                return ServerResponse.ok().body(Map.of(
+                    "code", 200,
+                    "msg", "Ok"
+                ));
+            } else {
+                return ServerResponse.status(401).body(Map.of(
+                    "code", 401,
+                    "msg", "Unauthorized"
+                ));
+            }
+        } catch (Exception ex) {
+            logger.error("Error en /logout", ex);
+            return ServerResponse.status(500).body(new Response("500", "Error interno al cerrar sesión"));
         }
     }
 }

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/UserController.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/controllers/UserController.java
@@ -81,8 +81,13 @@ public class UserController {
 
     public ServerResponse login(ServerRequest request) {
         try {
+            log.info("Received login request");
             LoginRequest dto = request.body(LoginRequest.class);
+            log.info("Login attempt for email: {}", dto.getEmail());
+            
             var resp = userService.login(dto.getEmail(), dto.getPassword());
+            log.info("Login response status: {}", resp.getStatusCodeValue());
+            
             return ServerResponse
                     .status(resp.getStatusCodeValue())
                     .body(resp.getBody());
@@ -91,6 +96,13 @@ public class UserController {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "Login failed",
+                    e
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error during login", e);
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Login failed unexpectedly",
                     e
             );
         }

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/LogoutRequest.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/models/LogoutRequest.java
@@ -1,0 +1,40 @@
+package upb.edu.AuthMicroservice.models;
+
+public class LogoutRequest {
+    private String email;
+    private String password;
+    private String session;
+
+    public LogoutRequest() {
+    }
+
+    public LogoutRequest(String email, String password, String session) {
+        this.email = email;
+        this.password = password;
+        this.session = session;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getSession() {
+        return session;
+    }
+
+    public void setSession(String session) {
+        this.session = session;
+    }
+}

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/routes/Routes.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/routes/Routes.java
@@ -40,6 +40,7 @@ public class Routes {
         return route()
                 .POST("/generate-session", sessionController::generateSession)
                 .POST("/refresh-token", sessionController::refreshToken)
+                .POST("/logout", sessionController::logout)
                 .build();
     }
 }

--- a/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/SessionService.java
+++ b/AuthMicroservice Backend/src/main/java/upb/edu/AuthMicroservice/services/SessionService.java
@@ -13,6 +13,7 @@ import upb.edu.AuthMicroservice.exceptions.InvalidRefreshTokenException;
 import upb.edu.AuthMicroservice.exceptions.InvalidSessionException;
 
 import upb.edu.AuthMicroservice.models.Session;
+import upb.edu.AuthMicroservice.models.User;
 import upb.edu.AuthMicroservice.repositories.SessionRepository;
 import upb.edu.AuthMicroservice.repositories.UserRepository;
 
@@ -20,18 +21,22 @@ import upb.edu.AuthMicroservice.repositories.UserRepository;
 @Service
 public class SessionService {
 
-    @Autowired
-    private SessionInteractor interactor;
+    private final SessionInteractor interactor;
+    private final RefreshTokenInteractor refreshTokenInteractor;
+    private final UserRepository userRepository;
+    private final SessionRepository sessionRepository;
 
     @Autowired
-
-    private RefreshTokenInteractor refreshTokenInteractor;
-
-    
-    private UserRepository userRepository;
-
-    @Autowired
-    private SessionRepository sessionRepository;
+    public SessionService(
+            SessionInteractor interactor,
+            RefreshTokenInteractor refreshTokenInteractor,
+            UserRepository userRepository,
+            SessionRepository sessionRepository) {
+        this.interactor = interactor;
+        this.refreshTokenInteractor = refreshTokenInteractor;
+        this.userRepository = userRepository;
+        this.sessionRepository = sessionRepository;
+    }
 
     public static class SessionCreationResult {
         private final UUID sessionId;
@@ -97,5 +102,34 @@ public class SessionService {
             }
             throw ex;
         }
+    }
+
+    public boolean logout(String email, String password, String sessionUuid) {
+        Optional<User> userOpt = userRepository.findByEmail(email);
+
+        if (userOpt.isEmpty() || !userOpt.get().getPassword().equals(password)) {
+            return false;
+        }
+
+        UUID sessionId;
+        try {
+            sessionId = UUID.fromString(sessionUuid);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+
+        Optional<Session> sessionOpt = sessionRepository.findById(sessionId);
+        if (sessionOpt.isEmpty()) {
+            return false;
+        }
+
+        Session session = sessionOpt.get();
+        if (session.getUserId() != userOpt.get().getId() || !session.isValid()) {
+            return false;
+        }
+
+        session.setIsValid(false);
+        sessionRepository.save(session);
+        return true;
     }
 }


### PR DESCRIPTION
Se implementó el endpoint POST /auth/logout para permitir a los usuarios cerrar su sesión de forma segura.

¿Cómo probarlo?
Para verificar la funcionalidad, se deben seguir los siguientes pasos en Postman:
Obtener una sesión: Primero, hacer una petición a POST /auth/login con credenciales válidas para obtener una session_id.
![Imagen de WhatsApp 2025-08-28 a las 18 20 31_c206e1e6](https://github.com/user-attachments/assets/fdf59b7c-d387-4ba3-94ad-3797604c2db7)
![Imagen de WhatsApp 2025-08-28 a las 18 19 44_45da0021](https://github.com/user-attachments/assets/a9199cfe-83a2-4a94-86ee-d7fbdae3944a)

Probar el cierre de sesión exitoso:
Método: POST
URL: http://localhost:8080/auth/logout
Body (raw, JSON):
JSON
{
    "email": "tu_email@gmail.com",
    "password": "tu_password_correcto",
    "session": "el_session_id_obtenido_en_el_paso_1"
}
Respuesta esperada: Status 200 OK y el cuerpo { "code": 200, "msg": "Ok" }.
![Imagen de WhatsApp 2025-08-28 a las 18 19 00_1324fa3a](https://github.com/user-attachments/assets/5510e25a-10ef-4b81-ad12-dbc3167ff4fc)

Probar con credenciales incorrectas:
Usar la misma petición pero con una contraseña incorrecta.
Respuesta esperada: Status 401 Unauthorized y el cuerpo { "code": 401, "msg": "Unauthorized" }.
![Imagen de WhatsApp 2025-08-28 a las 18 22 08_dbcc42da](https://github.com/user-attachments/assets/f8b06e44-dc94-464a-8cd5-e706465c9469)

